### PR TITLE
Increased minimum Ansible version to 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 matrix:
   include:
     - env:
-        - MOLECULEW_ANSIBLE=2.4.6
+        - MOLECULEW_ANSIBLE=2.5.10
         - MOLECULE_SCENARIO=default
       python: '2.7'
     - env:

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ Role to configure JDKs in the IntelliJ IDEA IDE
 Requirements
 ------------
 
-* Ansible
-
-    * Minimum 2.4
+* Ansible >= 2.5
 
 * Linux Distribution
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   author: John Freeman
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.4
+  min_ansible_version: 2.5
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
Ansible no longer supports versions earlier than 2.5.