### PR TITLE
Increased minimum Ansible version to 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   include:
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=default
       python: '2.7'
     - env:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Role to configure JDKs in the IntelliJ IDEA IDE
 Requirements
 ------------
 
-* Ansible >= 2.7
+* Ansible >= 2.8
 
 * Linux Distribution
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   author: John Freeman
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.7
+  min_ansible_version: 2.8
   platforms:
     - name: EL
       versions:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -53,6 +53,7 @@
         dest: '/opt/java/jdk-11'
         owner: root
         group: root
+        mode: 'o-w'
         creates: '/opt/java/jdk-11/jdk-11.0.3+7/bin'
 
     - name: set facts for openjdk locations


### PR DESCRIPTION
Ansible no longer supports versions earlier than 2.8.