### PR TITLE
Dropped support for Ubuntu Xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Requirements
 
         * Ubuntu
 
-            * Xenial (16.04)
             * Bionic (18.04)
             * Focal (20.04)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,6 @@ galaxy_info:
         - 7
     - name: Ubuntu
       versions:
-        - xenial
         - bionic
         - focal
   galaxy_tags:


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Xenial.